### PR TITLE
Update version selection in load_schema() 

### DIFF
--- a/docs/Classes/common.md
+++ b/docs/Classes/common.md
@@ -25,3 +25,11 @@ Below is a collection of the common classes that are used by other classes.
 ::: pyfdl.RoundStrategy
     options:
         inherited_members: false
+
+## Global Variables
+Version numbers are used as default values in [Header](header.md) and to select a matching json schema file
+if no version is set.
+
+::: pyfdl.FDL_SCHEMA_MAJOR
+::: pyfdl.FDL_SCHEMA_MINOR
+::: pyfdl.FDL_SCHEMA_VERSION

--- a/src/pyfdl/pyfdl.py
+++ b/src/pyfdl/pyfdl.py
@@ -1,10 +1,9 @@
 import json
 import uuid
-from typing import Type
-
 import jsonschema
-
+from typing import Type
 from pathlib import Path
+
 
 from pyfdl import (
     Base,
@@ -59,7 +58,7 @@ class FDL(Base):
 
     def validate(self):
         if not self._schema:
-            self._schema = FDL.load_schema()
+            self._schema = self.load_schema()
 
         jsonschema.validate(self.to_dict(), self._schema)
 
@@ -85,16 +84,19 @@ class FDL(Base):
         for attr in header.attributes:
             setattr(self, attr, getattr(header, attr))
 
-    @staticmethod
-    def load_schema() -> dict:
-        """Load a jsonschema that matches the current version of the spec
+    def load_schema(self) -> dict:
+        """Load a jsonschema based on the version in `Header` or default to current version
+        set in [base](common.md)
 
         Returns:
             schema:
         """
+        major = self.version.get('major') if self.version else FDL_SCHEMA_MAJOR
+        minor = self.version.get('minor') if self.version else FDL_SCHEMA_MINOR
+
         schema_path = Path(__file__).parent.joinpath(
             f'schema',
-            f'v{FDL_SCHEMA_MAJOR}.{FDL_SCHEMA_MINOR}',
+            f'v{major}.{minor}',
             f'Python_FDL_Checker'
         )
         with schema_path.open('rb') as fp:

--- a/src/pyfdl/schema/v0.1/Python_FDL_Checker
+++ b/src/pyfdl/schema/v0.1/Python_FDL_Checker
@@ -14,11 +14,11 @@
       "properties": {
         "major": {
           "type": "integer",
-          "const": 1
+          "const": 0
         },
         "minor": {
           "type": "integer",
-          "const": 0
+          "const": 1
         }
       },
       "required": [

--- a/tests/test_pyfdl.py
+++ b/tests/test_pyfdl.py
@@ -16,7 +16,8 @@ def test_load_unverified():
 
     assert isinstance(fdl, pyfdl.FDL)
     assert isinstance(fdl.header, pyfdl.Header)
-    assert fdl.header.uuid != ""
+    assert fdl.header.uuid == fdl.uuid
+    assert fdl.uuid != ""
 
 
 def test_load_verified():


### PR DESCRIPTION
Hacked a schema file to support version 1.0 of the spec.
Converted `load_schema()` to a regular method. It will now load the version set in the Header and fallback on version set in the global variables. 
Added global variables to documentation