### PR TITLE
Remove parent strategy

### DIFF
--- a/src/pyfdl/base.py
+++ b/src/pyfdl/base.py
@@ -123,11 +123,10 @@ class Base(ABC):
         return data
 
     @classmethod
-    def from_dict(cls, raw: dict, parent: Any = None) -> Any:
+    def from_dict(cls, raw: dict) -> Any:
         """Create instances of classes from a provided dict.
 
         Args:
-            parent: is used in collections of items
             raw: dictionary to convert to supported classes
 
         Returns:
@@ -149,22 +148,18 @@ class Base(ABC):
 
                     tc = TypedCollection(_cls)
                     for item in value:
-                        tc.add_item(_cls.from_dict(item, parent=tc))
+                        tc.add_item(_cls.from_dict(item))
                     value = tc
                 else:
                     value = cls.object_map[key].from_dict(value)
 
             kwargs[keyword] = value
 
-        if parent:
-            kwargs['parent'] = parent
-
         return cls(**kwargs)
 
     @staticmethod
     def generate_uuid():
         return str(uuid.uuid4())
-
 
     @abstractmethod
     def __repr__(self) -> str:
@@ -214,8 +209,6 @@ class TypedCollection:
 
         else:
             raise FDLError(f"Item must have a valid identifier (\"{self._cls.id_attribute}\"), not None or empty string")
-
-        item.parent = self
 
     def get_item(self, item_id: str) -> Union[Any, None]:
         """Get an item in the collection

--- a/src/pyfdl/canvas.py
+++ b/src/pyfdl/canvas.py
@@ -40,10 +40,8 @@ class Canvas(Base):
             photosite_dimensions: DimensionsInt = None,
             physical_dimensions: DimensionsFloat = None,
             anamorphic_squeeze: float = None,
-            framing_decisions: TypedCollection = None,
-            parent: TypedCollection = None
+            framing_decisions: TypedCollection = None
     ):
-        self.parent = parent
         self.label = label
         self.id = _id
         self.source_canvas_id = source_canvas_id
@@ -127,32 +125,6 @@ class Canvas(Base):
             return self.effective_dimensions, self.effective_anchor_point
 
         return self.dimensions, Point(x=0, y=0)
-
-    @property
-    def parent(self) -> Union[TypedCollection, None]:
-        return self._parent
-
-    @parent.setter
-    def parent(self, parent: TypedCollection):
-        self._parent = parent
-
-    @property
-    def source_canvas_id(self) -> str:
-        return self._source_canvas_id
-
-    @source_canvas_id.setter
-    def source_canvas_id(self, canvas_id: str):
-        if not canvas_id:
-            return
-
-        if self.parent and canvas_id in self.parent or canvas_id == self.id:
-            self._source_canvas_id = canvas_id
-
-        else:
-            raise FDLError(
-                f'"source_canvas_id" {canvas_id} must either be self.id or the id of another canvas in '
-                f'the registered canvases. {self.parent}'
-            )
 
     def __repr__(self):
         return f'{self.__class__.__name__}(label="{self.label}", id="{self.id}")'

--- a/src/pyfdl/canvas_template.py
+++ b/src/pyfdl/canvas_template.py
@@ -49,10 +49,8 @@ class CanvasTemplate(Base):
             preserve_from_source_canvas: str = None,
             maximum_dimensions: DimensionsInt = None,
             pad_to_maximum: bool = False,
-            _round: RoundStrategy = None,
-            parent: TypedCollection = None
+            _round: RoundStrategy = None
     ):
-        self.parent = parent
         self.label = label
         self.id = _id
         self.target_dimensions = target_dimensions
@@ -65,14 +63,6 @@ class CanvasTemplate(Base):
         self.maximum_dimensions = maximum_dimensions
         self.pad_to_maximum = pad_to_maximum
         self.round = _round
-
-    @property
-    def parent(self) -> Union[TypedCollection, None]:
-        return self._parent
-
-    @parent.setter
-    def parent(self, parent: TypedCollection):
-        self._parent = parent
 
     @property
     def fit_source(self) -> str:

--- a/src/pyfdl/framing_decision.py
+++ b/src/pyfdl/framing_decision.py
@@ -30,10 +30,8 @@ class FramingDecision(Base):
             dimensions: DimensionsFloat = None,
             anchor_point: Point = None,
             protection_dimensions: DimensionsFloat = None,
-            protection_anchor_point: Point = None,
-            parent: TypedCollection = None
+            protection_anchor_point: Point = None
     ):
-        self.parent = parent
         self.label = label
         self.id = _id
         self.framing_intent_id = framing_intent_id
@@ -41,14 +39,6 @@ class FramingDecision(Base):
         self.anchor_point = anchor_point
         self.protection_dimensions = protection_dimensions
         self.protection_anchor_point = protection_anchor_point
-
-    @property
-    def parent(self) -> Union[TypedCollection, None]:
-        return self._parent
-
-    @parent.setter
-    def parent(self, parent: TypedCollection):
-        self._parent = parent
 
     def __eq__(self, other):
         return (

--- a/src/pyfdl/framing_intent.py
+++ b/src/pyfdl/framing_intent.py
@@ -16,22 +16,12 @@ class FramingIntent(Base):
             label: str = None,
             _id: str = None,
             aspect_ratio: DimensionsInt = None,
-            protection: float = None,
-            parent: TypedCollection = None
+            protection: float = None
     ):
-        self.parent = parent
         self.id = _id
         self.label = label
         self.aspect_ratio = aspect_ratio
         self.protection = protection
-
-    @property
-    def parent(self) -> Union[TypedCollection, None]:
-        return self._parent
-
-    @parent.setter
-    def parent(self, parent: TypedCollection):
-        self._parent = parent
 
     def __repr__(self):
         return (f'{self.__class__.__name__}('

--- a/src/pyfdl/pyfdl.py
+++ b/src/pyfdl/pyfdl.py
@@ -122,20 +122,26 @@ class FDL(Base):
         errors = []
 
         # Check internal relations
-        for context in self.contexts:
-            for canvas in context.canvases:
-                if canvas.source_canvas_id not in context.canvases:
-                    errors.append(
-                        f'{canvas}.source_canvas_id (canvas.source_canvas_id) not found in '
-                        f'registered canvases'
-                    )
+        canvases = TypedCollection(Canvas)
+        canvas_collections = [context.canvases for context in self.contexts]
 
-                for framing_decision in canvas.framing_decisions:
-                    if framing_decision.framing_intent_id not in self.framing_intents:
-                        errors.append(
-                            f'{framing_decision}.framing_intent_id ({framing_decision.framing_intent_id}) '
-                            f'not found in registered framing intents'
-                        )
+        for canvas_collection in canvas_collections:
+            for canvas in canvas_collection:
+                canvases.add_item(canvas)
+
+        for canvas in canvases:
+            if canvases.get_item(canvas.source_canvas_id) is None:
+                errors.append(
+                    f'{canvas}.source_canvas_id (canvas.source_canvas_id) not found in '
+                    f'registered canvases'
+                )
+
+            for framing_decision in canvas.framing_decisions:
+                if framing_decision.framing_intent_id not in self.framing_intents:
+                    errors.append(
+                        f'{framing_decision}.framing_intent_id ({framing_decision.framing_intent_id}) '
+                        f'not found in registered framing intents'
+                    )
 
         # Check structure and values against json schema
         v = jsonschema.validators.validator_for(self._schema)

--- a/src/pyfdl/pyfdl.py
+++ b/src/pyfdl/pyfdl.py
@@ -132,7 +132,7 @@ class FDL(Base):
         for canvas in canvases:
             if canvases.get_item(canvas.source_canvas_id) is None:
                 errors.append(
-                    f'{canvas}.source_canvas_id (canvas.source_canvas_id) not found in '
+                    f'{canvas.source_canvas_id} (canvas.source_canvas_id) not found in '
                     f'registered canvases'
                 )
 
@@ -151,7 +151,7 @@ class FDL(Base):
 
         if errors:
             nl = '\n'
-            FDLValidationError(
+            raise FDLValidationError(
                 f"Validation failed!\n"
                 f"{f'{nl}'.join(errors)}"
             )


### PR DESCRIPTION
Refactored how we check for a valid canvas.source_canvas_id. This involved removing the parent attribute that most classes had only to support the old behavior in Canvas.
Updated unittests.
Also fixed a missing raise of FDLValidationError.